### PR TITLE
Fix incorrect use of order item meta

### DIFF
--- a/gifty-woocommerce.php
+++ b/gifty-woocommerce.php
@@ -4,16 +4,16 @@
  * Plugin URI: https://github.com/giftyhq/plugin-woocommerce
  * Description: WordPress plugin for accepting Gifty gift cards in your WooCommerce shop.
  * Domain Path: /languages
- * Version: 2.0.5
+ * Version: 2.0.6
  * Author: Gifty B.V.
  * Author URI: https://gifty.nl
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Requires PHP: 8.0
  * Requires at least: 6.2
- * Tested up to: 6.4
+ * Tested up to: 6.5
  * WC requires at least: 8.2.0
- * WC tested up to: 8.5.0
+ * WC tested up to: 8.5.2
  */
 
 declare( strict_types=1 );

--- a/inc/GiftCardManager.php
+++ b/inc/GiftCardManager.php
@@ -62,7 +62,9 @@ class GiftCardManager {
         }, $gift_cards );
 
         // Update WooCommerce order meta
-        wc_update_order_item_meta( $order_id, self::META_KEY, $gift_cards_data );
+        $order = wc_get_order( $order_id );
+		$order->update_meta_data( self::META_KEY, $gift_cards_data );
+		$order->save();
     }
 
     // Saves gift card data from the session to the order meta
@@ -90,7 +92,8 @@ class GiftCardManager {
      * @throws \Exception
      */
     public function get_gift_cards_from_order( int $order_id ): array {
-        $gift_cards_data = wc_get_order_item_meta( $order_id, self::META_KEY, true );
+		$order = wc_get_order( $order_id );
+		$gift_cards_data = $order->get_meta( self::META_KEY );
 
         if ( ! $gift_cards_data ) {
             return [];

--- a/inc/Migration/Migration_2.php
+++ b/inc/Migration/Migration_2.php
@@ -1,0 +1,116 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Gifty\WooCommerce\Migration;
+
+use Gifty\Client\GiftyClient;
+use Gifty\Client\Resources\GiftCard;
+use Gifty\Client\Resources\Transaction;
+use Gifty\WooCommerce\GiftCardManager;
+use Gifty\WooCommerce\SessionGiftCard;
+
+class Migration_2 implements MigrationInterface
+{
+
+    private GiftyClient     $client;
+    private GiftCardManager $manager;
+    public const DB_VERSION = 2;
+
+    public function __construct( GiftyClient $client )
+    {
+        $this->client = $client;
+        $this->manager = new GiftCardManager();
+    }
+
+    public static function schedule(): void
+    {
+        // This migration can be processed in the background, so we'll schedule it to run at a later moment
+        if ( false === as_has_scheduled_action( 'gifty_wc_execute_plugin_migration' ) ) {
+            as_enqueue_async_action( 'gifty_wc_execute_plugin_migration', [
+                'migration' => self::class,
+                'parameters' => [
+                    'offset' => 0,
+                ],
+            ] );
+        }
+    }
+
+    public function migrate( array $options = [] ): void
+    {
+        // Get all orders in a batch size of 50
+        $batchSize = 75;
+        $offset = $options['offset'];
+
+        // Get the orders to migrate. We'll only get orders after 2020-09-24 (the release date of the plugin)
+        $orders = wc_get_orders(
+            [
+                'limit' => $batchSize,
+                'offset' => $offset,
+                'status' => 'any',
+                'type' => 'shop_order',
+                'date_created' => '>2020-09-24',
+            ] );
+
+        // If there are no orders left, we are done
+        if ( empty( $orders ) ) {
+            // Update the DB version
+            update_option( 'gifty_db_version', self::DB_VERSION );
+
+            return;
+        }
+
+        // Schedule the next batch in 10 seconds
+        as_schedule_single_action( time() + 10, 'gifty_wc_execute_plugin_migration', [
+            'migration' => self::class,
+            'parameters' => [
+                'offset' => $offset + $batchSize,
+            ],
+        ] );
+
+        // Migrate the orders from this batch
+        foreach ( $orders as $order ) {
+            $this->migrate_order( $order );
+        }
+    }
+
+	/**
+	 * In this migration we'll migrate gift card data from order_item_meta to order_meta
+	 *
+	 * @param \WC_Order $order
+	 *
+	 * @return void
+	 */
+    private function migrate_order( \WC_Order $order ): void
+    {
+		// If the order has no wc_get_order_item_meta, the order doesn't contain gift card data and we return
+	    try {
+		    $deprecated_data = wc_get_order_item_meta( $order->get_id(), '_gifty_applied_gift_cards' );
+	    } catch ( \Exception $e ) {
+		    $deprecated_data = null;
+	    }
+
+	    if ( ! $deprecated_data ) {
+		    return;
+	    }
+
+		$deprecated_data_mapped = array_map( function ( array $data ): SessionGiftCard {
+			return new SessionGiftCard( ...$data );
+		}, $deprecated_data );
+
+
+        /*
+         * Try to update the order with the new gift cards
+         * As we might work with very old data, we'll just skip the order if we fail to prevent any issues
+         */
+        try {
+            // Add the gift cards to the order
+            $this->manager->upsert_gift_cards_to_order_meta( $order->get_id(), $deprecated_data_mapped );
+
+            // Remove the old order item meta
+	        wc_delete_order_item_meta( $order->get_id(), '_gifty_applied_gift_cards' );
+        } catch ( \Throwable $e ) {
+            return;
+        }
+    }
+}

--- a/inc/WC_Integration_Gifty.php
+++ b/inc/WC_Integration_Gifty.php
@@ -9,6 +9,7 @@ use Gifty\WooCommerce\Admin\WC_Gifty_Analytics;
 use Gifty\WooCommerce\Admin\WC_Gifty_Refunds;
 use Gifty\WooCommerce\Compatibility\CompatibilityRegister;
 use Gifty\WooCommerce\Migration\Migration_1;
+use Gifty\WooCommerce\Migration\Migration_2;
 use WC_Admin_Settings;
 use WC_Integration;
 
@@ -18,7 +19,7 @@ if ( !defined( 'ABSPATH' ) ) {
 
 final class WC_Integration_Gifty extends WC_Integration
 {
-    const DB_VERSION = 1;
+    const DB_VERSION = 2;
 
     public GiftyClient         $client;
     private WC_Gifty_Cart      $cart;
@@ -176,6 +177,7 @@ final class WC_Integration_Gifty extends WC_Integration
             // Define migrations with their version
             $migrations = [
                 Migration_1::DB_VERSION => Migration_1::class,
+	            Migration_2::DB_VERSION => Migration_2::class,
             ];
 
             // Schedule migrations until the DB version is updated

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:
 Tags: gifty, cadeaubon, cadeaukaart, woocommerce, gift card, gift cards, voucher
 Text Domain: gifty-woocommerce
 Requires at least: 6.2
-Tested up to: 6.4
-Stable tag: 2.0.5
+Tested up to: 6.5
+Stable tag: 2.0.6
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -32,6 +32,9 @@ No, this plugin has the purpose of accepting Gifty gift cards in your WooCommerc
 We're more than happy to help you out! You can contact us through our [contact page](https://gifty.nl/contact).
 
 == Changelog ==
+
+= 2.0.6 =
+* Fix incorrect use of order item meta to order meta data
 
 = 2.0.5 =
 * Removed the external dependency of jQuery BlockUI module


### PR DESCRIPTION
This commit changes the usage of 'wc_update_order_item_meta' to meta data on the actual order. This change includes a migration for current data stored as order item meta.